### PR TITLE
Add installcheck_script based on Graham Gilbert's here: https://github.c...

### DIFF
--- a/make_profile_pkg.py
+++ b/make_profile_pkg.py
@@ -99,6 +99,10 @@ def main():
             "profiles are supported.")
         sys.exit("Error: %s" % e.message)
 
+    # Grab other profile metadata for use in Munki's pkginfo
+    profile_display_name = pdata.get("PayloadDisplayName")
+    profile_description = pdata.get("PayloadDescription", '')
+
     # Version
     version = opts.version
     if not version:
@@ -209,6 +213,8 @@ fi
         subprocess.call([
             munkiimport,
             "--nointeractive",
+            "--displayname", profile_display_name or item_name,
+            "--description", profile_description, 
             "--subdirectory", opts.munki_repo_destination,
             "--uninstall-script", uninstall_script_path,
             "--installcheck-script", installcheck_script_path,


### PR DESCRIPTION
...om/grahamgilbert/mactech_2014/blob/master/Profile/installcheck_script_v2.sh

This change adds an installcheck_script to the Munki pkginfo based on Graham Gilbert's work. The effect is that if the profile is removed (via the Profiles preferences pane or the /usr/bin/profiles command), Munki will detect this and reinstall the profile.
